### PR TITLE
Add osconf to configuring logging and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 raven
 tablib
 pymongo<3.0
+osconf

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     install_requires=[
         "raven",
         "pymongo<3.0",
-        "tablib"
+        "tablib",
+        "osconf"
     ],
     test_suite='tests',
 )

--- a/sippers/__init__.py
+++ b/sippers/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from osconf import config_from_environment
+
 try:
     VERSION = __import__('pkg_resources') \
         .get_distribution(__name__).version
@@ -9,5 +11,6 @@ except Exception, e:
 
 from sippers.logging import setup_logging
 
+logging_config = config_from_environment('SIPPERS_LOGGING')
 
-logger = setup_logging()
+logger = setup_logging(**logging_config)

--- a/sippers/logging.py
+++ b/sippers/logging.py
@@ -42,7 +42,12 @@ def setup_logging(level=None, logfile=None):
     sentry_handler = SentryHandler(sentry, level=logging.ERROR)
     logger.addHandler(sentry_handler)
 
+    if isinstance(level, basestring):
+        level = getattr(logging, level.upper(), None)
+
     if level is None:
-        logger.setLevel(logging.INFO)
+        level = logging.INFO
+
+    logger.setLevel(level)
 
     return logger

--- a/tests/tests_logging.py
+++ b/tests/tests_logging.py
@@ -1,0 +1,39 @@
+import logging
+import sys
+import os
+import unittest
+
+
+class OsConfLoggingTest(unittest.TestCase):
+    def tearDown(self):
+        for key in os.environ.keys():
+            if key.startswith('SIPPERS_LOGGING'):
+                os.environ.pop(key)
+
+    def test_default_level_is_logging(self):
+        from sippers import logger
+        reload(sys.modules['sippers'])
+
+        self.assertEqual(logger.level, logging.INFO)
+
+    def test_config_level_from_environment(self):
+        os.environ['SIPPERS_LOGGING_LEVEL'] = 'DEBUG'
+        # Reload the module to recreate sippers.logger
+        reload(sys.modules['sippers'])
+        from sippers import logger
+
+        self.assertEqual(logger.level, logging.DEBUG)
+
+    def test_config_file_from_environement(self):
+        import tempfile
+        logfile = tempfile.mkstemp(prefix='sippers-test-')[1]
+        os.environ['SIPPERS_LOGGING_LOGFILE'] = logfile
+        # Reload the module to recreate sippers.logger
+        reload(sys.modules['sippers'])
+        from sippers import logger
+
+        logger.info('Foo')
+        with open(logfile, 'r') as f:
+            logcontent = f.read()
+        self.assertRegexpMatches(logcontent, "\[[0-9]{4}-[0-9]{2}-[0-9]{2} "
+        "[0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}\] INFO .*: Foo")


### PR DESCRIPTION
- Add support to config sippers logging system through environment variables with `SIPPERS_LOGGING`prefix.
- `SIPPERS_LOGGING_LEVEL`: Sets the level of logging
- `SIPPERS_LOGGING_LOGFILE`: Sets logfile path and enable logging via logfile
