### PR TITLE
Update marshmallow requirements < 3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 raven
 pymongo<3.0
 osconf
-marshmallow>=2.0.0b2
+marshmallow<3.0
 click

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "raven",
         "pymongo<3.0",
         "osconf",
-        "marshmallow>=2.0.0b2",
+        "marshmallow<3.0",
         "click"
     ],
     test_suite='tests',


### PR DESCRIPTION
New version of marshmallow is not backwards compatible. 

https://github.com/marshmallow-code/marshmallow/commit/cc69995c6843aa3ae9c379ce627e7a1c2ed1be07#diff-e3a9e9dc10800b5f3b5ba9d5c1014c68R151

https://github.com/gisce/sippers/blob/master/sippers/adapters/__init__.py#L2

